### PR TITLE
[failOnError] show eslint errors when failOnError is disabled

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -145,6 +145,9 @@ class ESLintWebpackPlugin {
         if (errors && options.failOnError) {
           // @ts-ignore
           compilation.errors.push(errors);
+        } else if (errors && !options.failOnError) {
+          // @ts-ignore
+          compilation.warnings.push(errors);
         }
 
         if (generateReportAsset) {


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Eslint errors are no longer shown when you disable `failOnError`. See https://github.com/webpack-contrib/eslint-webpack-plugin/issues/84

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
